### PR TITLE
remove unused 'use' in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,7 @@ extern crate futures;
 extern crate tokio_timer;
 extern crate tokio_retry;
 
-use std::time::Duration;
-use std::default::Default;
-use futures::future::Future;
+use futures::Future;
 use tokio_timer::Timer;
 use tokio_retry::RetryFuture;
 use tokio_retry::strategy::{ExponentialBackoff, jitter};


### PR DESCRIPTION
I also changed the Future import to the short one.