### PR TITLE
Add max_delay option

### DIFF
--- a/src/strategy/exponential_backoff.rs
+++ b/src/strategy/exponential_backoff.rs
@@ -1,11 +1,11 @@
 use std::time::Duration;
 use std::iter::Iterator;
-use std::u64::{MAX as U64_MAX};
+use std::u64::MAX as U64_MAX;
 
 /// A retry strategy driven by exponential back-off.
 ///
 /// The power corresponds to the number of past attempts.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct ExponentialBackoff {
     current: u64,
     base: u64

--- a/src/strategy/exponential_backoff.rs
+++ b/src/strategy/exponential_backoff.rs
@@ -8,7 +8,8 @@ use std::u64::MAX as U64_MAX;
 #[derive(Debug, Clone)]
 pub struct ExponentialBackoff {
     current: u64,
-    base: u64
+    base: u64,
+    factor: u64,
 }
 
 impl ExponentialBackoff {
@@ -18,7 +19,21 @@ impl ExponentialBackoff {
     /// The resulting duration is calculated by taking the base to the `n`-th power,
     /// where `n` denotes the number of past attempts.
     pub fn from_millis(base: u64) -> ExponentialBackoff {
-        ExponentialBackoff{current: base, base: base}
+        ExponentialBackoff {
+            current: base,
+            base: base,
+            factor: 1u64,
+        }
+    }
+
+    /// A multiplicative factor that will be applied to the retry delay.
+    ///
+    /// For example, using a factor of `1000` will make each delay in units of seconds.
+    ///
+    /// Default factor is `1`.
+    pub fn factor(mut self, factor: u64) -> ExponentialBackoff {
+        self.factor = factor;
+        self
     }
 }
 
@@ -26,7 +41,12 @@ impl Iterator for ExponentialBackoff {
     type Item = Duration;
 
     fn next(&mut self) -> Option<Duration> {
-        let duration = Duration::from_millis(self.current);
+        // set delay duration by applying factor
+        let duration = if let Some(duration) = self.current.checked_mul(self.factor) {
+            Duration::from_millis(duration)
+        } else {
+            Duration::from_millis(U64_MAX)
+        };
 
         if let Some(next) = self.current.checked_mul(self.base) {
             self.current = next;
@@ -34,7 +54,7 @@ impl Iterator for ExponentialBackoff {
             self.current = U64_MAX;
         }
 
-        return Some(duration);
+        Some(duration)
     }
 }
 
@@ -63,4 +83,14 @@ fn saturates_at_maximum_value() {
     assert_eq!(s.next(), Some(Duration::from_millis(U64_MAX - 1)));
     assert_eq!(s.next(), Some(Duration::from_millis(U64_MAX)));
     assert_eq!(s.next(), Some(Duration::from_millis(U64_MAX)));
+}
+
+#[test]
+fn can_use_factor_to_get_seconds() {
+    let factor = 1000;
+    let mut s = ExponentialBackoff::from_millis(2).factor(factor);
+
+    assert_eq!(s.next(), Some(Duration::from_secs(2)));
+    assert_eq!(s.next(), Some(Duration::from_secs(4)));
+    assert_eq!(s.next(), Some(Duration::from_secs(8)));
 }

--- a/src/strategy/fibonacci_backoff.rs
+++ b/src/strategy/fibonacci_backoff.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 use std::iter::Iterator;
-use std::u64::{MAX as U64_MAX};
+use std::u64::MAX as U64_MAX;
 
 /// A retry strategy driven by the fibonacci series.
 ///
@@ -12,7 +12,7 @@ use std::u64::{MAX as U64_MAX};
 ///
 /// See ["A Performance Comparison of Different Backoff Algorithms under Different Rebroadcast Probabilities for MANETs."](http://www.comp.leeds.ac.uk/ukpew09/papers/12.pdf)
 /// for more details.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct FibonacciBackoff {
     curr: u64,
     next: u64

--- a/src/strategy/fixed_interval.rs
+++ b/src/strategy/fixed_interval.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 use std::iter::Iterator;
 
 /// A retry strategy driven by a fixed interval.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct FixedInterval {
     duration: Duration
 }


### PR DESCRIPTION
Hi,
Thanks for making this crate. I really like it! I saw in the older version you had a max delay option for the strategies, but on master that has been removed during the tokio changes.

I tried adding that back in today. I'm not sure if this is the approach you had in mind, or even wanted this sort of behavior... Anyhow, here's what I came up with. I thought it would be more straight-forward, but the functions `Duration` provides are not exactly the best for this use case: e.g. `checked_mul` on a Duration, only takes a `u32`, not `u64`,  you can't multiply a `Duration` by another `Duration`, etc. I was hoping I could have stored `base`/`curr` as a `Duration` in the iterator, but that just didn't work out.

I also added a `ExponentialBackoff::from_secs` function (since the `from_millis` one didn't give me the right behavior I wanted (too fast or too slow). Also added some `Debug` impls.

Happy to address any comments.

Thanks!