### PR TITLE
Add possibility to attempt retry only if a given condition is true

### DIFF
--- a/src/condition.rs
+++ b/src/condition.rs
@@ -1,0 +1,9 @@
+pub trait Condition<E> {
+    fn should_retry(&mut self, error: &E) -> bool;
+}
+
+impl<E, F: FnMut(&E) -> bool> Condition<E> for F {
+    fn should_retry(&mut self, error: &E) -> bool {
+        self(error)
+    }
+}

--- a/src/condition.rs
+++ b/src/condition.rs
@@ -1,3 +1,4 @@
+/// Specifies under which conditions a retry is attempted.
 pub trait Condition<E> {
     fn should_retry(&mut self, error: &E) -> bool;
 }

--- a/src/future.rs
+++ b/src/future.rs
@@ -97,6 +97,8 @@ impl<I, A> Future for Retry<I, A> where I: Iterator<Item=Duration>, A: Action {
     }
 }
 
+/// Future that drives multiple attempts at an action via a retry strategy. Retries are only attempted if
+/// the `Error` returned by the future satisfies a given condition.
 pub struct RetryIf<I, A, C> where I: Iterator<Item=Duration>, A: Action, C: Condition<A::Error> {
     strategy: I,
     state: RetryState<A>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,11 +46,13 @@ extern crate tokio_core;
 extern crate tokio_service;
 
 mod action;
+mod condition;
 mod future;
 pub mod middleware;
 /// Assorted retry strategies including fixed interval and exponential back-off.
 pub mod strategy;
 
 pub use action::Action;
-pub use future::{Error, Retry};
+pub use condition::Condition;
+pub use future::{Error, Retry, RetryIf};
 pub use middleware::Middleware;


### PR DESCRIPTION
Hi,

That's a very nice looking and useful crate 👍.

For my use case however I would like to retry only if certain conditions are true. (See [https://github.com/df5602/bingers/blob/3c132fb4a04c0ecd9bba113caa861dd0e077fdd8/src/tvmaze_api.rs]() lines 176ff for an example.)

So I've added the possibility to give a predicate to the Retry future (similar to `filter()` with iterators). Retry is only attempted if the predicate returns true. I thought, I'd open a pull request in case you find this a useful feature to have.

Unfortunately I've had to box the closure (otherwise it's not possible to instantiate `Retry` if no condition is given). Maybe there's a better way to achieve this?

Feel free to suggest a better API and other improvements if you have any better ideas.