### PR TITLE
Update to tokio 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,11 @@ keywords = ["futures", "tokio", "retry", "exponential", "backoff"]
 edition = "2018"
 
 [dependencies]
-futures = "0.1.11"
+futures = "0.3.1"
 rand = "0.4.0"
-tokio-timer = "0.2.1"
+tokio = { version = "0.2", features = ["time"] }
+pin-project = "0.4.6"
 
 [dev-dependencies]
 quickcheck = "0.6.0"
-tokio = "0.1.5"
-tokio-core = "0.1.17"
+tokio = { version = "0.2", features = ["rt-core", "time"] }

--- a/src/action.rs
+++ b/src/action.rs
@@ -1,9 +1,9 @@
-use futures::{IntoFuture, Future};
+use futures::future::Future;
 
 /// An action can be run multiple times and produces a future.
 pub trait Action {
     /// The future that this action produces.
-    type Future: Future<Item=Self::Item, Error=Self::Error>;
+    type Future: Future<Output=Result<Self::Item, Self::Error>>;
     /// The item that the future may resolve with.
     type Item;
     /// The error that the future may resolve with.
@@ -12,12 +12,12 @@ pub trait Action {
     fn run(&mut self) -> Self::Future;
 }
 
-impl<T: IntoFuture, F: FnMut() -> T> Action for F {
-    type Item = T::Item;
-    type Error = T::Error;
-    type Future = T::Future;
+impl<R, E, T: Future<Output = Result<R, E>>, F: FnMut() -> T> Action for F {
+    type Item = R;
+    type Error = E;
+    type Future = T;
 
     fn run(&mut self) -> Self::Future {
-        self().into_future()
+        self()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,57 +13,26 @@
 //!
 //! # Examples
 //!
-//! ## Using the new `tokio` crate
+//! ## Using the `tokio` crate
 //!
 //! ```rust
-//! # extern crate futures;
 //! # extern crate tokio;
 //! # extern crate tokio_retry;
-//! #
-//! # use futures::Future;
-//! # use futures::future::lazy;
-//! use tokio_retry::Retry;
-//! use tokio_retry::strategy::{ExponentialBackoff, jitter};
-//!
-//! fn action() -> Result<u64, ()> {
-//!     // do some real-world stuff here...
-//!     Err(())
-//! }
-//!
-//! # fn main() {
-//! let retry_strategy = ExponentialBackoff::from_millis(10)
-//!     .map(jitter)
-//!     .take(3);
-//!
-//! let future = Retry::spawn(retry_strategy, action).then(|result| {
-//!     println!("result {:?}", result);
-//!     Ok(())
-//! });
-//!
-//! tokio::run(future);
-//! # }
-//! ```
-//!
-//! ## Using the `tokio_core` crate
-//!
-//! ```rust
 //! # extern crate futures;
-//! # extern crate tokio_core;
-//! # extern crate tokio_retry;
 //! #
-//! # use futures::Future;
-//! # use futures::future::lazy;
-//! use tokio_core::reactor::Core;
+//! # use std::future::Future;
+//! # use futures::prelude::*;
+//! use tokio::runtime::Runtime;
 //! use tokio_retry::Retry;
 //! use tokio_retry::strategy::{ExponentialBackoff, jitter};
 //!
-//! fn action() -> Result<u64, ()> {
+//! fn action() -> impl Future<Output=Result<u64, ()>> {
 //!     // do some real-world stuff here...
-//!     Err(())
+//!     futures::future::err(())
 //! }
 //!
 //! # fn main() {
-//! let mut core = Core::new().unwrap();
+//! let mut rt = Runtime::new().unwrap();
 //!
 //! let retry_strategy = ExponentialBackoff::from_millis(10)
 //!     .map(jitter)
@@ -71,12 +40,14 @@
 //!
 //! let future = Retry::spawn(retry_strategy, action).then(|result| {
 //!     println!("result {:?}", result);
-//!     Ok::<_, ()>(())
+//!     futures::future::ok::<_, ()>(())
 //! });
 //!
-//! core.run(future).unwrap();
+//! rt.block_on(future);
 //! # }
 //! ```
+
+#![allow(warnings)]
 
 mod action;
 mod condition;
@@ -86,4 +57,4 @@ pub mod strategy;
 
 pub use action::Action;
 pub use condition::Condition;
-pub use future::{Error, Retry, RetryIf};
+pub use future::{Retry, RetryIf};

--- a/tests/future.rs
+++ b/tests/future.rs
@@ -1,25 +1,25 @@
-use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 
-use futures::Future;
-use futures::sync::oneshot::spawn;
+use futures::future::{err, ok};
+use std::iter::Take;
 use tokio::runtime::Runtime;
-use tokio_core::reactor::Core;
-use tokio_retry::{Error, Retry, RetryIf};
+use tokio_retry::{Retry, RetryIf};
 
 #[test]
 fn attempts_just_once() {
     use std::iter::empty;
-    let runtime = Runtime::new().unwrap();
+    let mut runtime = Runtime::new().unwrap();
     let counter = Arc::new(AtomicUsize::new(0));
     let cloned_counter = counter.clone();
     let future = Retry::spawn(empty(), move || {
         cloned_counter.fetch_add(1, Ordering::SeqCst);
-        Err::<(), u64>(42)
+        err::<(), u64>(42)
     });
-    let res = spawn(future, &runtime.executor()).wait();
 
-    assert_eq!(res, Err(Error::OperationError(42)));
+    let res = runtime.block_on(future);
+
+    assert_eq!(res, Err(42));
     assert_eq!(counter.load(Ordering::SeqCst), 1);
 }
 
@@ -27,16 +27,16 @@ fn attempts_just_once() {
 fn attempts_until_max_retries_exceeded() {
     use tokio_retry::strategy::FixedInterval;
     let s = FixedInterval::from_millis(100).take(2);
-    let runtime = Runtime::new().unwrap();
+    let mut runtime = Runtime::new().unwrap();
     let counter = Arc::new(AtomicUsize::new(0));
     let cloned_counter = counter.clone();
     let future = Retry::spawn(s, move || {
         cloned_counter.fetch_add(1, Ordering::SeqCst);
-        Err::<(), u64>(42)
+        err::<(), u64>(42)
     });
-    let res = spawn(future, &runtime.executor()).wait();
+    let res = runtime.block_on(future);
 
-    assert_eq!(res, Err(Error::OperationError(42)));
+    assert_eq!(res, Err(42));
     assert_eq!(counter.load(Ordering::SeqCst), 3);
 }
 
@@ -44,18 +44,18 @@ fn attempts_until_max_retries_exceeded() {
 fn attempts_until_success() {
     use tokio_retry::strategy::FixedInterval;
     let s = FixedInterval::from_millis(100);
-    let runtime = Runtime::new().unwrap();
+    let mut runtime = Runtime::new().unwrap();
     let counter = Arc::new(AtomicUsize::new(0));
     let cloned_counter = counter.clone();
     let future = Retry::spawn(s, move || {
         let previous = cloned_counter.fetch_add(1, Ordering::SeqCst);
         if previous < 3 {
-            Err::<(), u64>(42)
+            err::<(), u64>(42)
         } else {
-            Ok::<(), u64>(())
+            ok::<(), u64>(())
         }
     });
-    let res = spawn(future, &runtime.executor()).wait();
+    let res = runtime.block_on(future);
 
     assert_eq!(res, Ok(()));
     assert_eq!(counter.load(Ordering::SeqCst), 4);
@@ -65,18 +65,18 @@ fn attempts_until_success() {
 fn compatible_with_tokio_core() {
     use tokio_retry::strategy::FixedInterval;
     let s = FixedInterval::from_millis(100);
-    let mut core = Core::new().unwrap();
+    let mut rt = Runtime::new().unwrap();
     let counter = Arc::new(AtomicUsize::new(0));
     let cloned_counter = counter.clone();
     let future = Retry::spawn(s, move || {
         let previous = cloned_counter.fetch_add(1, Ordering::SeqCst);
         if previous < 3 {
-            Err::<(), u64>(42)
+            err::<(), u64>(42)
         } else {
-            Ok::<(), u64>(())
+            ok::<(), u64>(())
         }
     });
-    let res = core.run(future);
+    let res = rt.block_on(future);
 
     assert_eq!(res, Ok(()));
     assert_eq!(counter.load(Ordering::SeqCst), 4);
@@ -86,15 +86,19 @@ fn compatible_with_tokio_core() {
 fn attempts_retry_only_if_given_condition_is_true() {
     use tokio_retry::strategy::FixedInterval;
     let s = FixedInterval::from_millis(100).take(5);
-    let runtime = Runtime::new().unwrap();
+    let mut runtime = Runtime::new().unwrap();
     let counter = Arc::new(AtomicUsize::new(0));
     let cloned_counter = counter.clone();
-    let future = RetryIf::spawn(s, move || {
-        let previous  = cloned_counter.fetch_add(1, Ordering::SeqCst);
-        Err::<(), usize>(previous + 1)
-    }, |e: &usize| *e < 3);
-    let res = spawn(future, &runtime.executor()).wait();
+    let future: RetryIf<Take<FixedInterval>, _, fn(&usize) -> _> = RetryIf::spawn(
+        s,
+        move || {
+            let previous = cloned_counter.fetch_add(1, Ordering::SeqCst);
+            err::<(), usize>(previous + 1)
+        },
+        |e: &usize| *e < 3,
+    );
+    let res = runtime.block_on(future);
 
-    assert_eq!(res, Err(Error::OperationError(3)));
+    assert_eq!(res, Err(3));
     assert_eq!(counter.load(Ordering::SeqCst), 3);
 }


### PR DESCRIPTION
This change is very similar to https://github.com/srijs/rust-tokio-retry/pull/14
Diffrences:
- using "unsafe-project" instead of "pin-utils"
- no explicit "unsafe" code in the "rust-tokio-retry" 
