### PR TITLE
Optional jitter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 Cargo.lock
+.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,12 @@ keywords = ["futures", "tokio", "retry", "exponential", "backoff"]
 edition = "2018"
 
 [dependencies]
-rand = "0.8.3"
+rand = { version = "0.8.3", optional = true }
 tokio = { version = "1.0", features = ["time"] }
 pin-project = "1.0.5"
+
+[features]
+jitter = ["rand"]
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["full"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 //! # extern crate tokio_retry;
 //! #
 //! use tokio_retry::Retry;
-//! use tokio_retry::strategy::{ExponentialBackoff, jitter};
+//! use tokio_retry::strategy::ExponentialBackoff;
 //!
 //! async fn action() -> Result<u64, ()> {
 //!     // do some real-world stuff here...
@@ -27,13 +27,38 @@
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), ()> {
 //! let retry_strategy = ExponentialBackoff::from_millis(10)
-//!     .map(jitter) // add jitter to delays
 //!     .take(3);    // limit to 3 retries
 //!
 //! let result = Retry::spawn(retry_strategy, action).await?;
 //! # Ok(())
 //! # }
 //! ```
+//!
+//! # Features
+//! [jitter]
+//!
+//! To use jitter, add this to your Cargo.toml
+//!
+//! ```toml
+//! [dependencies]
+//! tokio-retry = { version = "0.3", features = ["jitter"] }
+//! ```
+//!
+//! # Example
+//!
+//! ```rust,no_run
+//! # extern crate tokio;
+//! # extern crate tokio_retry;
+//! #
+//! use tokio_retry::Retry;
+//! use tokio_retry::strategy::{ExponentialBackoff, jitter};
+//!
+//! let retry_strategy = ExponentialBackoff::from_millis(10)
+//!    .map(jitter) // add jitter to the retry interval
+//!    .take(3);    // limit to 3 retries
+//!
+//!
+//!
 
 #![allow(warnings)]
 

--- a/src/strategy/jitter.rs
+++ b/src/strategy/jitter.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+
 pub fn jitter(duration: Duration) -> Duration {
     duration.mul_f64(rand::random::<f64>())
 }

--- a/src/strategy/mod.rs
+++ b/src/strategy/mod.rs
@@ -8,4 +8,6 @@ mod jitter;
 pub use self::exponential_backoff::ExponentialBackoff;
 pub use self::fibonacci_backoff::FibonacciBackoff;
 pub use self::fixed_interval::FixedInterval;
+
+#[cfg(feature = "jitter")]
 pub use self::jitter::jitter;

--- a/src/strategy/mod.rs
+++ b/src/strategy/mod.rs
@@ -1,6 +1,8 @@
 mod exponential_backoff;
 mod fibonacci_backoff;
 mod fixed_interval;
+
+#[cfg(feature = "jitter")]
 mod jitter;
 
 pub use self::exponential_backoff::ExponentialBackoff;


### PR DESCRIPTION
Make the jitter map an optional feature, to support no_std crates (without getrandom support)