### PR TITLE
Update edition

### DIFF
--- a/.github/workflows/outdated.yml
+++ b/.github/workflows/outdated.yml
@@ -1,8 +1,6 @@
 name: Outdated
 
 on:
-  push:
-    branches: [ "*" ]
   pull_request:
     branches: [ "*" ]
   schedule:

--- a/.github/workflows/outdated.yml
+++ b/.github/workflows/outdated.yml
@@ -1,0 +1,24 @@
+name: Outdated
+
+on:
+  push:
+    branches: [ "*" ]
+  pull_request:
+    branches: [ "*" ]
+  schedule:
+    - cron: "0 0 1,15 * *"
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  outdated:
+    name: Dependencies
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install cargo-outdated
+      run: cargo install --locked cargo-outdated
+    - name: Check for outdated dependencies
+      run: cargo outdated -R --exit-code 1 

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -12,8 +12,19 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  tests:
+  outdated:
+    name: Outdated dependencies
+    runs-on: ubuntu-latest
 
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install cargo-outdated
+      run: cargo install --locked cargo-outdated
+    - name: Check for outdated dependencies
+      run: cargo outdated -R --exit-code 1 
+      
+  tests:
+    name: Tests
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -2,7 +2,7 @@ name: Rust
 
 on:
   push:
-    branches: [ "*" ]
+    branches: [ "master" ]
   pull_request:
     branches: [ "*" ]
 

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -1,0 +1,64 @@
+name: Rust
+
+on:
+  push:
+    branches: [ "*" ]
+  pull_request:
+    branches: [ "*" ]
+  schedule:
+    - cron: "0 0 1,15 * *"
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  tests:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build
+      run: cargo build
+    - name: Tests
+      run: cargo test --verbose
+
+# Run cargo clippy -- -D warnings
+  clippy_check:
+    name: Clippy
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.toml') }}
+      - name: Install stable@stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - name: Run clippy
+        run: cargo clippy -- -W clippy::all -D warnings
+
+  # Run cargo fmt --all -- --check
+  format:
+    name: Format
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Install stable@stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - name: Run cargo fmt
+        run: cargo fmt --all -- --check

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -5,24 +5,11 @@ on:
     branches: [ "*" ]
   pull_request:
     branches: [ "*" ]
-  schedule:
-    - cron: "0 0 1,15 * *"
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  outdated:
-    name: Outdated dependencies
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v3
-    - name: Install cargo-outdated
-      run: cargo install --locked cargo-outdated
-    - name: Check for outdated dependencies
-      run: cargo outdated -R --exit-code 1 
-      
   tests:
     name: Tests
     runs-on: ubuntu-latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: rust
-rust:
-  - stable
-  - beta
-  - nightly
-cache: cargo
-matrix:
-  allow_failures:
-    - rust: nightly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## Version 0.4.0
+## Version 0.4.0 @ [#29](https://github.com/srijs/rust-tokio-retry/pull/29)
 
 - Adds github actions removing obsolete travis.ci.
+- Bimonthly runs CI checking for outdated dependencies.
 - Applies const to functions that can be const.
 - Adds linting defaults.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## Version 0.4.0
+
+- Adds github actions removing obsolete travis.ci.
+- Applies const to functions that can be const.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@
 
 - Adds github actions removing obsolete travis.ci.
 - Applies const to functions that can be const.
+- Adds linting defaults.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-retry"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Sam Rijs <srijs@airpost.net>"]
 description = "Extensible, asynchronous retry behaviours for futures/tokio"
 license = "MIT"
@@ -8,7 +8,7 @@ readme = "README.md"
 repository = "https://github.com/srijs/rust-tokio-retry"
 documentation = "https://docs.rs/tokio-retry"
 keywords = ["futures", "tokio", "retry", "exponential", "backoff"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 rand = "0.8.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,16 @@ keywords = ["futures", "tokio", "retry", "exponential", "backoff"]
 edition = "2021"
 
 [dependencies]
-rand = "0.8.3"
-tokio = { version = "1.0", features = ["time"] }
-pin-project = "1.0.5"
+rand = "0.8.5"
+tokio = { version = "1.40", features = ["time"] }
+pin-project = "1.1.5"
 
 [dev-dependencies]
-tokio = { version = "1.0", features = ["full"] }
+tokio = { version = "1.40", features = ["full"] }
+
+[lints.clippy]
+correctness = { level = "deny", priority = -1 }
+suspicious = { level = "deny", priority = 2 }
+style = { level = "deny", priority = 0 }
+complexity = { level = "warn", priority = 3 }
+perf = { level = "deny", priority = 1 }

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-tokio-retry = "0.3"
+tokio-retry = "0.4"
 ```
 
 ## Examples

--- a/src/future.rs
+++ b/src/future.rs
@@ -107,8 +107,8 @@ where
         RetryIf {
             strategy: strategy.into_iter(),
             state: RetryState::Running(action.run()),
-            action: action,
-            condition: condition,
+            action,
+            condition,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! tokio-retry = "0.3"
+//! tokio-retry = "0.4"
 //! ```
 //!
 //! # Example

--- a/src/strategy/exponential_backoff.rs
+++ b/src/strategy/exponential_backoff.rs
@@ -1,6 +1,5 @@
 use std::iter::Iterator;
 use std::time::Duration;
-use std::u64::MAX as U64_MAX;
 
 /// A retry strategy driven by exponential back-off.
 ///
@@ -22,7 +21,7 @@ impl ExponentialBackoff {
     pub const fn from_millis(base: u64) -> ExponentialBackoff {
         ExponentialBackoff {
             current: base,
-            base: base,
+            base,
             factor: 1u64,
             max_delay: None,
         }
@@ -53,7 +52,7 @@ impl Iterator for ExponentialBackoff {
         let duration = if let Some(duration) = self.current.checked_mul(self.factor) {
             Duration::from_millis(duration)
         } else {
-            Duration::from_millis(U64_MAX)
+            Duration::from_millis(u64::MAX)
         };
 
         // check if we reached max delay
@@ -66,7 +65,7 @@ impl Iterator for ExponentialBackoff {
         if let Some(next) = self.current.checked_mul(self.base) {
             self.current = next;
         } else {
-            self.current = U64_MAX;
+            self.current = u64::MAX;
         }
 
         Some(duration)
@@ -93,11 +92,11 @@ fn returns_some_exponential_base_2() {
 
 #[test]
 fn saturates_at_maximum_value() {
-    let mut s = ExponentialBackoff::from_millis(U64_MAX - 1);
+    let mut s = ExponentialBackoff::from_millis(u64::MAX - 1);
 
-    assert_eq!(s.next(), Some(Duration::from_millis(U64_MAX - 1)));
-    assert_eq!(s.next(), Some(Duration::from_millis(U64_MAX)));
-    assert_eq!(s.next(), Some(Duration::from_millis(U64_MAX)));
+    assert_eq!(s.next(), Some(Duration::from_millis(u64::MAX - 1)));
+    assert_eq!(s.next(), Some(Duration::from_millis(u64::MAX)));
+    assert_eq!(s.next(), Some(Duration::from_millis(u64::MAX)));
 }
 
 #[test]

--- a/src/strategy/exponential_backoff.rs
+++ b/src/strategy/exponential_backoff.rs
@@ -19,7 +19,7 @@ impl ExponentialBackoff {
     ///
     /// The resulting duration is calculated by taking the base to the `n`-th power,
     /// where `n` denotes the number of past attempts.
-    pub fn from_millis(base: u64) -> ExponentialBackoff {
+    pub const fn from_millis(base: u64) -> ExponentialBackoff {
         ExponentialBackoff {
             current: base,
             base: base,
@@ -33,13 +33,13 @@ impl ExponentialBackoff {
     /// For example, using a factor of `1000` will make each delay in units of seconds.
     ///
     /// Default factor is `1`.
-    pub fn factor(mut self, factor: u64) -> ExponentialBackoff {
+    pub const fn factor(mut self, factor: u64) -> ExponentialBackoff {
         self.factor = factor;
         self
     }
 
     /// Apply a maximum delay. No retry delay will be longer than this `Duration`.
-    pub fn max_delay(mut self, duration: Duration) -> ExponentialBackoff {
+    pub const fn max_delay(mut self, duration: Duration) -> ExponentialBackoff {
         self.max_delay = Some(duration);
         self
     }

--- a/src/strategy/fibonacci_backoff.rs
+++ b/src/strategy/fibonacci_backoff.rs
@@ -1,6 +1,5 @@
 use std::iter::Iterator;
 use std::time::Duration;
-use std::u64::MAX as U64_MAX;
 
 /// A retry strategy driven by the fibonacci series.
 ///
@@ -57,7 +56,7 @@ impl Iterator for FibonacciBackoff {
         let duration = if let Some(duration) = self.curr.checked_mul(self.factor) {
             Duration::from_millis(duration)
         } else {
-            Duration::from_millis(U64_MAX)
+            Duration::from_millis(u64::MAX)
         };
 
         // check if we reached max delay
@@ -72,7 +71,7 @@ impl Iterator for FibonacciBackoff {
             self.next = next_next;
         } else {
             self.curr = self.next;
-            self.next = U64_MAX;
+            self.next = u64::MAX;
         }
 
         Some(duration)
@@ -92,9 +91,9 @@ fn returns_the_fibonacci_series_starting_at_10() {
 
 #[test]
 fn saturates_at_maximum_value() {
-    let mut iter = FibonacciBackoff::from_millis(U64_MAX);
-    assert_eq!(iter.next(), Some(Duration::from_millis(U64_MAX)));
-    assert_eq!(iter.next(), Some(Duration::from_millis(U64_MAX)));
+    let mut iter = FibonacciBackoff::from_millis(u64::MAX);
+    assert_eq!(iter.next(), Some(Duration::from_millis(u64::MAX)));
+    assert_eq!(iter.next(), Some(Duration::from_millis(u64::MAX)));
 }
 
 #[test]

--- a/src/strategy/fibonacci_backoff.rs
+++ b/src/strategy/fibonacci_backoff.rs
@@ -23,7 +23,7 @@ pub struct FibonacciBackoff {
 impl FibonacciBackoff {
     /// Constructs a new fibonacci back-off strategy,
     /// given a base duration in milliseconds.
-    pub fn from_millis(millis: u64) -> FibonacciBackoff {
+    pub const fn from_millis(millis: u64) -> FibonacciBackoff {
         FibonacciBackoff {
             curr: millis,
             next: millis,
@@ -37,13 +37,13 @@ impl FibonacciBackoff {
     /// For example, using a factor of `1000` will make each delay in units of seconds.
     ///
     /// Default factor is `1`.
-    pub fn factor(mut self, factor: u64) -> FibonacciBackoff {
+    pub const fn factor(mut self, factor: u64) -> FibonacciBackoff {
         self.factor = factor;
         self
     }
 
     /// Apply a maximum delay. No retry delay will be longer than this `Duration`.
-    pub fn max_delay(mut self, duration: Duration) -> FibonacciBackoff {
+    pub const fn max_delay(mut self, duration: Duration) -> FibonacciBackoff {
         self.max_delay = Some(duration);
         self
     }

--- a/src/strategy/fixed_interval.rs
+++ b/src/strategy/fixed_interval.rs
@@ -9,8 +9,8 @@ pub struct FixedInterval {
 
 impl FixedInterval {
     /// Constructs a new fixed interval strategy.
-    pub fn new(duration: Duration) -> FixedInterval {
-        FixedInterval { duration: duration }
+    pub const fn new(duration: Duration) -> FixedInterval {
+        FixedInterval { duration }
     }
 
     /// Constructs a new fixed interval strategy,


### PR DESCRIPTION
## Version 0.4.0

- Adds github actions removing obsolete travis.ci.
- Bimonthly runs CI checking for outdated dependencies.
- Applies const to functions that can be const.
- Adds linting defaults.

CI workflow can be found here: https://github.com/naomijub/rust-tokio-retry/pull/1 