### PR TITLE
Define behaviour based on error

### DIFF
--- a/.github/workflows/outdated.yml
+++ b/.github/workflows/outdated.yml
@@ -1,8 +1,6 @@
 name: Outdated
 
 on:
-  push:
-    branches: [ "*" ]
   pull_request:
     branches: [ "*" ]
   schedule:

--- a/.github/workflows/outdated.yml
+++ b/.github/workflows/outdated.yml
@@ -1,0 +1,24 @@
+name: Outdated
+
+on:
+  push:
+    branches: [ "*" ]
+  pull_request:
+    branches: [ "*" ]
+  schedule:
+    - cron: "0 0 1,15 * *"
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  outdated:
+    name: Dependencies
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install cargo-outdated
+      run: cargo install --locked cargo-outdated
+    - name: Check for outdated dependencies
+      run: cargo outdated -R --exit-code 1 

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -19,7 +19,7 @@ jobs:
     - name: Build
       run: cargo build
     - name: Tests
-      run: cargo test --verbose
+      run: cargo test --all-features
 
 # Run cargo clippy -- -D warnings
   clippy_check:
@@ -44,7 +44,7 @@ jobs:
         with:
           components: clippy
       - name: Run clippy
-        run: cargo clippy -- -W clippy::all -D warnings
+        run: cargo clippy --all-features -- -W clippy::all -D warnings
 
   # Run cargo fmt --all -- --check
   format:

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -2,7 +2,7 @@ name: Rust
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "master", "main" ]
   pull_request:
     branches: [ "*" ]
 

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -12,8 +12,19 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  tests:
+  outdated:
+    name: Outdated dependencies
+    runs-on: ubuntu-latest
 
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install cargo-outdated
+      run: cargo install --locked cargo-outdated
+    - name: Check for outdated dependencies
+      run: cargo outdated -R --exit-code 1 
+      
+  tests:
+    name: Tests
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -2,7 +2,7 @@ name: Rust
 
 on:
   push:
-    branches: [ "*" ]
+    branches: [ "master" ]
   pull_request:
     branches: [ "*" ]
 

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -1,0 +1,64 @@
+name: Rust
+
+on:
+  push:
+    branches: [ "*" ]
+  pull_request:
+    branches: [ "*" ]
+  schedule:
+    - cron: "0 0 1,15 * *"
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  tests:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build
+      run: cargo build
+    - name: Tests
+      run: cargo test --verbose
+
+# Run cargo clippy -- -D warnings
+  clippy_check:
+    name: Clippy
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.toml') }}
+      - name: Install stable@stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - name: Run clippy
+        run: cargo clippy -- -W clippy::all -D warnings
+
+  # Run cargo fmt --all -- --check
+  format:
+    name: Format
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Install stable@stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - name: Run cargo fmt
+        run: cargo fmt --all -- --check

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -5,24 +5,11 @@ on:
     branches: [ "*" ]
   pull_request:
     branches: [ "*" ]
-  schedule:
-    - cron: "0 0 1,15 * *"
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  outdated:
-    name: Outdated dependencies
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v3
-    - name: Install cargo-outdated
-      run: cargo install --locked cargo-outdated
-    - name: Check for outdated dependencies
-      run: cargo outdated -R --exit-code 1 
-      
   tests:
     name: Tests
     runs-on: ubuntu-latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: rust
-rust:
-  - stable
-  - beta
-  - nightly
-cache: cargo
-matrix:
-  allow_failures:
-    - rust: nightly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## Version 0.4.0
+## Version 0.4.0 @ [#29](https://github.com/srijs/rust-tokio-retry/pull/29)
 
 - Adds github actions removing obsolete travis.ci.
+- Bimonthly runs CI checking for outdated dependencies.
 - Applies const to functions that can be const.
 - Adds linting defaults.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## Version 0.4.0 @ [#29](https://github.com/srijs/rust-tokio-retry/pull/29)
 
+- Adds `Retry::spawn_notify` to notify a retry with the associated `Error` and current `Duration`, PR [#4](https://github.com/naomijub/tokio-retry/pull/4).
 - Adds github actions removing obsolete travis.ci.
-- Bimonthly runs CI checking for outdated dependencies.
+- Bi-monthly runs CI checking for outdated dependencies.
 - Applies const to functions that can be const.
 - Adds linting defaults.
 - Optional jitter from @fuzzbuck PR [#26](https://github.com/srijs/rust-tokio-retry/pull/26)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## Version 0.4.0
+
+- Adds github actions removing obsolete travis.ci.
+- Applies const to functions that can be const.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,4 @@
 - Applies const to functions that can be const.
 - Adds linting defaults.
 - Optional jitter from @fuzzbuck PR [#26](https://github.com/srijs/rust-tokio-retry/pull/26)
+- Implements max_interval from @pzmarzly PR [#27](https://github.com/srijs/rust-tokio-retry/pull/27)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 0.5.0 @ [#30](https://github.com/srijs/rust-tokio-retry/pull/30)
+
+- Adds `RetryError` type inspired by [`backoff Error`](https://docs.rs/backoff/latest/backoff/enum.Error.html) where user can define Errors as `Transient` and `Permanent` so it is possible to early exit a retry. 
+
 ## Version 0.4.0 @ [#29](https://github.com/srijs/rust-tokio-retry/pull/29)
 
 - Adds `Retry::spawn_notify` to notify a retry with the associated `Error` and current `Duration`, PR [#4](https://github.com/naomijub/tokio-retry/pull/4).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@
 
 - Adds github actions removing obsolete travis.ci.
 - Applies const to functions that can be const.
+- Adds linting defaults.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@
 - Bimonthly runs CI checking for outdated dependencies.
 - Applies const to functions that can be const.
 - Adds linting defaults.
+- Optional jitter from @fuzzbuck PR [#26](https://github.com/srijs/rust-tokio-retry/pull/26)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "tokio-retry"
+name = "tokio-retry2"
 version = "0.4.0"
-authors = ["Sam Rijs <srijs@airpost.net>"]
+authors = ["Julia Naomi <jnboeira@outlook.com>","Sam Rijs <srijs@airpost.net>"]
 description = "Extensible, asynchronous retry behaviours for futures/tokio"
 license = "MIT"
 readme = "README.md"
-repository = "https://github.com/srijs/rust-tokio-retry"
-documentation = "https://docs.rs/tokio-retry"
+repository = "https://github.com/naomijub/tokio-retry"
+documentation = "https://docs.rs/tokio-retry2"
 keywords = ["futures", "tokio", "retry", "exponential", "backoff"]
 edition = "2021"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,11 @@ documentation = "https://docs.rs/tokio-retry2"
 keywords = ["futures", "tokio", "retry", "exponential", "backoff"]
 edition = "2021"
 
+[features]
+jitter = ["rand"]
+
 [dependencies]
-rand = "0.8.5"
+rand = { version = "0.8.5", optional = true }
 tokio = { version = "1.40", features = ["time"] }
 pin-project = "1.1.5"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-retry"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Sam Rijs <srijs@airpost.net>"]
 description = "Extensible, asynchronous retry behaviours for futures/tokio"
 license = "MIT"
@@ -8,7 +8,7 @@ readme = "README.md"
 repository = "https://github.com/srijs/rust-tokio-retry"
 documentation = "https://docs.rs/tokio-retry"
 keywords = ["futures", "tokio", "retry", "exponential", "backoff"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 rand = "0.8.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 readme = "README.md"
 repository = "https://github.com/naomijub/tokio-retry"
 documentation = "https://docs.rs/tokio-retry2"
-keywords = ["tokio", "retry", "exponential backoff"]
+keywords = ["tokio", "retry", "backoff"]
 edition = "2021"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 readme = "README.md"
 repository = "https://github.com/naomijub/tokio-retry"
 documentation = "https://docs.rs/tokio-retry2"
-keywords = ["futures", "tokio", "retry", "exponential", "backoff"]
+keywords = ["tokio", "retry", "exponential backoff"]
 edition = "2021"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,16 @@ keywords = ["futures", "tokio", "retry", "exponential", "backoff"]
 edition = "2021"
 
 [dependencies]
-rand = "0.8.3"
-tokio = { version = "1.0", features = ["time"] }
-pin-project = "1.0.5"
+rand = "0.8.5"
+tokio = { version = "1.40", features = ["time"] }
+pin-project = "1.1.5"
 
 [dev-dependencies]
-tokio = { version = "1.0", features = ["full"] }
+tokio = { version = "1.40", features = ["full"] }
+
+[lints.clippy]
+correctness = { level = "deny", priority = -1 }
+suspicious = { level = "deny", priority = 2 }
+style = { level = "deny", priority = 0 }
+complexity = { level = "warn", priority = 3 }
+perf = { level = "deny", priority = 1 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-retry2"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Julia Naomi <jnboeira@outlook.com>","Sam Rijs <srijs@airpost.net>"]
 description = "Extensible, asynchronous retry behaviours for futures/tokio"
 license = "MIT"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+test:
+	cargo test --all-features
+
+clippy:
+	cargo clippy --all-features -- -W clippy::all -W clippy::nursery -D warnings
+
+fmt:
+	cargo fmt --all
+
+lint: fmt clippy
+
+all: fmt clippy test
+
+pedantic:
+	cargo clippy --all-features -- -W clippy::pedantic -D warnings

--- a/README.md
+++ b/README.md
@@ -44,3 +44,33 @@ async fn main() -> Result<(), ()> {
     Ok(())
 }
 ```
+
+Or, to retry with a notification function:
+
+```rust
+use tokio_retry2::Retry;
+use tokio_retry2::strategy::{ExponentialBackoff, jitter, MaxInterval};
+
+async fn action() -> Result<u64, std::io::Error> {
+    // do some real-world stuff here...
+    Err(())
+}
+
+fn notify(err: &std::io::Error, duration: std::time::Duration) {
+    tracing::info!("Error {err:?} ocurred at {duration:?}");
+}
+
+#[tokio::main]
+async fn main() -> Result<(), ()> {
+    let retry_strategy = ExponentialBackoff::from_millis(10)
+        .factor(1) // multiplication factor applied to deplay
+        .max_delay_millis(100) // set max delay between retries to 500ms
+        .max_interval(10000) // set max interval to 10 seconds
+        .map(jitter) // add jitter to delays
+        .take(3);    // limit to 3 retries
+
+    let result = Retry::spawn_notify(retry_strategy, action, notify).await?;
+
+    Ok(())
+}
+```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # tokio-retry2
 
-Forked from https://github.com/srijs/rust-tokio-retry to keep it up-to-date
+Forked from https://github.com/srijs/rust-tokio-retry2 to keep it up-to-date
 
 Extensible, asynchronous retry behaviours for the ecosystem of [tokio](https://tokio.rs/) libraries.
 
@@ -16,7 +16,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-tokio-retry = "0.4"
+tokio-retry2 = "0.4"
 ```
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -33,8 +33,10 @@ async fn action() -> Result<u64, ()> {
 #[tokio::main]
 async fn main() -> Result<(), ()> {
     let retry_strategy = ExponentialBackoff::from_millis(10)
-        .map(jitter) // add jitter to delays
+        .factor(1) // multiplication factor applied to deplay
+        .max_delay_millis(100) // set max delay between retries to 500ms
         .max_interval(10000) // set max interval to 10 seconds
+        .map(jitter) // add jitter to delays
         .take(3);    // limit to 3 retries
 
     let result = Retry::spawn(retry_strategy, action).await?;

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
-# tokio-retry
+# tokio-retry2
+
+Forked from https://github.com/srijs/rust-tokio-retry to keep it up-to-date
 
 Extensible, asynchronous retry behaviours for the ecosystem of [tokio](https://tokio.rs/) libraries.
 
-[![Build Status](https://travis-ci.org/srijs/rust-tokio-retry.svg?branch=master)](https://travis-ci.org/srijs/rust-tokio-retry)
-[![crates](http://meritbadge.herokuapp.com/tokio-retry)](https://crates.io/crates/tokio-retry)
-[![dependency status](https://deps.rs/repo/github/srijs/rust-tokio-retry/status.svg)](https://deps.rs/repo/github/srijs/rust-tokio-retry)
+[![crates](http://meritbadge.herokuapp.com/tokio-retry2)](https://crates.io/crates/tokio-retry2)
+[![dependency status](https://deps.rs/repo/github/naomijub/tokio-retry2/status.svg)](https://deps.rs/repo/github/namijub/tokio-retry)
 
 
-[Documentation](https://docs.rs/tokio-retry)
+[Documentation](https://docs.rs/tokio-retry2)
 
 ## Installation
 
@@ -21,8 +22,8 @@ tokio-retry = "0.4"
 ## Examples
 
 ```rust
-use tokio_retry::Retry;
-use tokio_retry::strategy::{ExponentialBackoff, jitter};
+use tokio_retry2::Retry;
+use tokio_retry2::strategy::{ExponentialBackoff, jitter};
 
 async fn action() -> Result<u64, ()> {
     // do some real-world stuff here...

--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-tokio-retry2 = "0.4"
+tokio-retry2 = { version = "0.4", features = ["jitter"] }
 ```
 
 ## Examples
 
 ```rust
 use tokio_retry2::Retry;
-use tokio_retry2::strategy::{ExponentialBackoff, jitter};
+use tokio_retry2::strategy::{ExponentialBackoff, jitter, MaxInterval};
 
 async fn action() -> Result<u64, ()> {
     // do some real-world stuff here...
@@ -34,6 +34,7 @@ async fn action() -> Result<u64, ()> {
 async fn main() -> Result<(), ()> {
     let retry_strategy = ExponentialBackoff::from_millis(10)
         .map(jitter) // add jitter to delays
+        .max_interval(10000) // set max interval to 10 seconds
         .take(3);    // limit to 3 retries
 
     let result = Retry::spawn(retry_strategy, action).await?;

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-tokio-retry2 = { version = "0.4", features = ["jitter"] }
+tokio-retry2 = { version = "0.5", features = ["jitter"] }
 ```
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-tokio-retry = "0.3"
+tokio-retry = "0.4"
 ```
 
 ## Examples

--- a/src/action.rs
+++ b/src/action.rs
@@ -1,9 +1,10 @@
+use crate::error::Error as RetryError;
 use std::future::Future;
 
 /// An action can be run multiple times and produces a future.
 pub trait Action {
     /// The future that this action produces.
-    type Future: Future<Output = Result<Self::Item, Self::Error>>;
+    type Future: Future<Output = Result<Self::Item, RetryError<Self::Error>>>;
     /// The item that the future may resolve with.
     type Item;
     /// The error that the future may resolve with.
@@ -12,7 +13,7 @@ pub trait Action {
     fn run(&mut self) -> Self::Future;
 }
 
-impl<R, E, T: Future<Output = Result<R, E>>, F: FnMut() -> T> Action for F {
+impl<R, E, T: Future<Output = Result<R, RetryError<E>>>, F: FnMut() -> T> Action for F {
     type Item = R;
     type Error = E;
     type Future = T;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,195 @@
+use std::error;
+use std::fmt;
+
+use std::time::Duration;
+
+/// `Error` is the error value in an actions's retry result.
+///
+/// Based on the two possible values, the operation
+/// may be retried.
+pub enum Error<E> {
+    /// `Permanent` means that it's impossible to execute the operation
+    /// successfully. This error is an early return from the retry operation.
+    Permanent(E),
+
+    /// `Transient` means that the error is temporary. If the `retry_after` is `None`
+    /// the operation should be retried according to the defined strategy policy, else after
+    /// the specified duration. Useful for handling ratelimits like a HTTP 429 response.
+    Transient {
+        err: E,
+        retry_after: Option<Duration>,
+    },
+}
+
+impl<E> Error<E> {
+    // Creates an permanent error.
+    pub fn permanent(err: E) -> Self {
+        Error::Permanent(err)
+    }
+
+    // Creates a Result::Err container with an permanent error.
+    pub fn to_permanent<T>(err: E) -> Result<T, Self> {
+        Err(Error::Permanent(err))
+    }
+
+    // Creates an transient error which is retried according to the defined strategy
+    // policy.
+    pub fn transient(err: E) -> Self {
+        Error::Transient {
+            err,
+            retry_after: None,
+        }
+    }
+
+    // Creates a Result::Err container with an transient error which
+    // is retried according to the defined strategy policy.
+    pub fn to_transient<T>(err: E) -> Result<T, Self> {
+        Err(Error::Transient {
+            err,
+            retry_after: None,
+        })
+    }
+
+    /// Creates a Result::Err container with a transient error which
+    /// is retried after the specified duration.
+    /// Useful for handling ratelimits like a HTTP 429 response.
+    pub fn to_retry_after<T>(err: E, duration: Duration) -> Result<T, Self> {
+        Err(Error::Transient {
+            err,
+            retry_after: Some(duration),
+        })
+    }
+
+    /// Creates a transient error which is retried after the specified duration.
+    /// Useful for handling ratelimits like a HTTP 429 response.
+    pub fn retry_after(err: E, duration: Duration) -> Self {
+        Error::Transient {
+            err,
+            retry_after: Some(duration),
+        }
+    }
+}
+
+impl<E> fmt::Display for Error<E>
+where
+    E: fmt::Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            Error::Permanent(ref err)
+            | Error::Transient {
+                ref err,
+                retry_after: _,
+            } => err.fmt(f),
+        }
+    }
+}
+
+impl<E> fmt::Debug for Error<E>
+where
+    E: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        let (name, err) = match *self {
+            Error::Permanent(ref err) => ("Permanent", err as &dyn fmt::Debug),
+            Error::Transient {
+                ref err,
+                retry_after: _,
+            } => ("Transient", err as &dyn fmt::Debug),
+        };
+        f.debug_tuple(name).field(err).finish()
+    }
+}
+
+impl<E> error::Error for Error<E>
+where
+    E: error::Error,
+{
+    fn description(&self) -> &str {
+        match *self {
+            Error::Permanent(_) => "permanent error",
+            Error::Transient { .. } => "transient error",
+        }
+    }
+
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match *self {
+            Error::Permanent(ref err)
+            | Error::Transient {
+                ref err,
+                retry_after: _,
+            } => err.source(),
+        }
+    }
+
+    fn cause(&self) -> Option<&dyn error::Error> {
+        self.source()
+    }
+}
+
+/// By default all errors are transient. Permanent errors can
+/// be constructed explicitly. This implementation is for making
+/// the question mark operator (?) and the `try!` macro to work.
+impl<E> From<E> for Error<E> {
+    fn from(err: E) -> Error<E> {
+        Error::Transient {
+            err,
+            retry_after: None,
+        }
+    }
+}
+
+impl<E> PartialEq for Error<E>
+where
+    E: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Error::Permanent(ref self_err), Error::Permanent(ref other_err)) => {
+                self_err == other_err
+            }
+            (
+                Error::Transient {
+                    err: self_err,
+                    retry_after: self_retry_after,
+                },
+                Error::Transient {
+                    err: other_err,
+                    retry_after: other_retry_after,
+                },
+            ) => self_err == other_err && self_retry_after == other_retry_after,
+            _ => false,
+        }
+    }
+}
+
+#[test]
+fn create_permanent_error() {
+    let e = Error::permanent("err");
+    assert_eq!(e, Error::Permanent("err"));
+}
+
+#[test]
+fn create_transient_error() {
+    let e = Error::transient("err");
+    assert_eq!(
+        e,
+        Error::Transient {
+            err: "err",
+            retry_after: None
+        }
+    );
+}
+
+#[test]
+fn create_transient_error_with_retry_after() {
+    let retry_after = Duration::from_secs(42);
+    let e = Error::retry_after("err", retry_after);
+    assert_eq!(
+        e,
+        Error::Transient {
+            err: "err",
+            retry_after: Some(retry_after),
+        }
+    );
+}

--- a/src/future.rs
+++ b/src/future.rs
@@ -9,6 +9,8 @@ use std::task::{Context, Poll};
 use pin_project::pin_project;
 use tokio::time::{sleep_until, Duration, Instant, Sleep};
 
+use crate::notify::Notify;
+
 use super::action::Action;
 use super::condition::Condition;
 
@@ -46,7 +48,7 @@ where
     A: Action,
 {
     #[pin]
-    retry_if: RetryIf<I, A, fn(&A::Error) -> bool>,
+    retry_if: RetryIf<I, A, fn(&A::Error) -> bool, fn(&A::Error, std::time::Duration)>,
 }
 
 impl<I, A> Retry<I, A>
@@ -59,7 +61,27 @@ where
         action: A,
     ) -> Retry<I, A> {
         Retry {
-            retry_if: RetryIf::spawn(strategy, action, (|_| true) as fn(&A::Error) -> bool),
+            retry_if: RetryIf::spawn(
+                strategy,
+                action,
+                (|_| true) as fn(&A::Error) -> bool,
+                (|_, _| {}) as fn(&A::Error, std::time::Duration),
+            ),
+        }
+    }
+
+    pub fn spawn_notify<T: IntoIterator<IntoIter = I, Item = Duration>>(
+        strategy: T,
+        action: A,
+        notify: fn(&A::Error, std::time::Duration),
+    ) -> Retry<I, A> {
+        Retry {
+            retry_if: RetryIf::spawn(
+                strategy,
+                action,
+                (|_| true) as fn(&A::Error) -> bool,
+                notify,
+            ),
         }
     }
 }
@@ -80,35 +102,42 @@ where
 /// Future that drives multiple attempts at an action via a retry strategy. Retries are only attempted if
 /// the `Error` returned by the future satisfies a given condition.
 #[pin_project]
-pub struct RetryIf<I, A, C>
+pub struct RetryIf<I, A, C, N>
 where
     I: Iterator<Item = Duration>,
     A: Action,
     C: Condition<A::Error>,
+    N: Notify<A::Error>,
 {
     strategy: I,
     #[pin]
     state: RetryState<A>,
     action: A,
     condition: C,
+    duration: Duration,
+    notify: N,
 }
 
-impl<I, A, C> RetryIf<I, A, C>
+impl<I, A, C, N> RetryIf<I, A, C, N>
 where
     I: Iterator<Item = Duration>,
     A: Action,
     C: Condition<A::Error>,
+    N: Notify<A::Error>,
 {
     pub fn spawn<T: IntoIterator<IntoIter = I, Item = Duration>>(
         strategy: T,
         mut action: A,
         condition: C,
-    ) -> RetryIf<I, A, C> {
+        notify: N,
+    ) -> RetryIf<I, A, C, N> {
         RetryIf {
             strategy: strategy.into_iter(),
             state: RetryState::Running(action.run()),
             action,
             condition,
+            duration: Duration::from_millis(0),
+            notify,
         }
     }
 
@@ -132,6 +161,7 @@ where
         match self.as_mut().project().strategy.next() {
             None => Err(err),
             Some(duration) => {
+                *self.as_mut().project().duration += duration;
                 let deadline = Instant::now() + duration;
                 let future = sleep_until(deadline);
                 self.as_mut()
@@ -144,11 +174,12 @@ where
     }
 }
 
-impl<I, A, C> Future for RetryIf<I, A, C>
+impl<I, A, C, N> Future for RetryIf<I, A, C, N>
 where
     I: Iterator<Item = Duration>,
     A: Action,
     C: Condition<A::Error>,
+    N: Notify<A::Error>,
 {
     type Output = Result<A::Item, A::Error>;
 
@@ -159,6 +190,8 @@ where
                 Poll::Pending => Poll::Pending,
                 Poll::Ready(Err(err)) => {
                     if self.as_mut().project().condition.should_retry(&err) {
+                        let duration = self.as_ref().project_ref().duration.clone();
+                        self.as_mut().project().notify.notify(&err, duration);
                         match self.retry(err, cx) {
                             Ok(poll) => poll,
                             Err(err) => Poll::Ready(Err(err)),

--- a/src/future.rs
+++ b/src/future.rs
@@ -107,8 +107,8 @@ where
         RetryIf {
             strategy: strategy.into_iter(),
             state: RetryState::Running(action.run()),
-            action: action,
-            condition: condition,
+            action,
+            condition,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! tokio-retry = "0.4"
+//! tokio-retry2 = "0.4"
 //! ```
 //!
 //! # Example
@@ -15,7 +15,7 @@
 //! ```rust,no_run
 
 //! use tokio_retry2::Retry;
-//! use tokio_retry2::strategy::{ExponentialBackoff, jitter};
+//! use tokio_retry2::strategy::ExponentialBackoff;
 //!
 //! async fn action() -> Result<u64, ()> {
 //!     // do some real-world stuff here...
@@ -25,13 +25,35 @@
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), ()> {
 //! let retry_strategy = ExponentialBackoff::from_millis(10)
-//!     .map(jitter) // add jitter to delays
 //!     .take(3);    // limit to 3 retries
 //!
 //! let result = Retry::spawn(retry_strategy, action).await?;
 //! # Ok(())
 //! # }
 //! ```
+//!
+//! # Features
+//! `[jitter]``
+//!
+//! To use jitter, add this to your Cargo.toml
+//!
+//! ```toml
+//! [dependencies]
+//! tokio-retry2 = { version = "0.4", features = ["jitter"] }
+//! ```
+//!
+//! # Example
+//!
+//! ```rust,no_run
+//! use tokio_retry2::Retry;
+//! use tokio_retry2::strategy::{ExponentialBackoff, jitter};
+//!
+//! let retry_strategy = ExponentialBackoff::from_millis(10)
+//!    .map(jitter) // add jitter to the retry interval
+//!    .take(3);    // limit to 3 retries
+//!
+//!
+//!
 
 #![allow(warnings)]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,11 +13,9 @@
 //! # Example
 //!
 //! ```rust,no_run
-//! # extern crate tokio;
-//! # extern crate tokio_retry;
-//! #
-//! use tokio_retry::Retry;
-//! use tokio_retry::strategy::{ExponentialBackoff, jitter};
+
+//! use tokio_retry2::Retry;
+//! use tokio_retry2::strategy::{ExponentialBackoff, jitter};
 //!
 //! async fn action() -> Result<u64, ()> {
 //!     // do some real-world stuff here...

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,10 +25,13 @@
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), ()> {
 //! let retry_strategy = ExponentialBackoff::from_millis(10)
-//!     .max_interval(10000) // set max interval to 10 seconds
+//!     .factor(1) // multiplication factor applied to deplay
+//!     .max_delay_millis(100) // set max delay between retries to 500ms
+//!     .max_interval(1000) // set max interval to 1 second for all retries
 //!     .take(3);    // limit to 3 retries
 //!
 //! let result = Retry::spawn(retry_strategy, action).await?;
+
 //! # Ok(())
 //! # }
 //! ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! tokio-retry = "0.3"
+//! tokio-retry = "0.4"
 //! ```
 //!
 //! # Example

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,23 +7,23 @@
 //!
 //! ```toml
 //! [dependencies]
-//! tokio-retry2 = "0.4"
+//! tokio-retry2 = "0.5"
 //! ```
 //!
 //! # Example
 //!
 //! ```rust,no_run
 
-//! use tokio_retry2::Retry;
+//! use tokio_retry2::{Retry, RetryError};
 //! use tokio_retry2::strategy::{ExponentialBackoff, MaxInterval};
 //!
-//! async fn action() -> Result<u64, ()> {
+//! async fn action() -> Result<u64, RetryError<()>> {
 //!     // do some real-world stuff here...
-//!     Err(())
+//!     RetryError::to_permanent(())
 //! }
 //!
 //! # #[tokio::main]
-//! # async fn main() -> Result<(), ()> {
+//! # async fn main() -> Result<(), RetryError<()>> {
 //! let retry_strategy = ExponentialBackoff::from_millis(10)
 //!     .factor(1) // multiplication factor applied to deplay
 //!     .max_delay_millis(100) // set max delay between retries to 500ms
@@ -36,14 +36,50 @@
 //! # }
 //! ```
 //!
-//! # Features
+//! ## Error Handling
+//!
+//! One key difference between `tokio-retry2` and `tokio-retry` is the fact that `tokio-retry2`
+//! supports early exits from the retry loop based on your error type. This allows you to pattern match
+//! your errors and define if you want to continue retrying or not. The following functions are
+//! helper functions to deal with it:
+//!
+//! ```rust,no_run
+//! use tokio_retry2::{Retry, RetryError};
+//! use std::time::Duration;
+//!
+//! async fn action() -> Result<u64, RetryError<usize>> {
+//!     // do some real-world stuff here...
+//!     // get and error named `err`
+//! #   let err = std::io::ErrorKind::AddrInUse;
+//!     match err {
+//!         std::io::ErrorKind::NotFound => RetryError::to_permanent(1)?, // equivalent to return Err(RetryError::permanent(2))`;
+//!         std::io::ErrorKind::PermissionDenied => {
+//!             return Err(RetryError::permanent(2)); // equivalent to `RetryError::to_permanent(2)`
+//!         }
+//!         std::io::ErrorKind::ConnectionRefused => {
+//!             return Err(RetryError::transient(3)); // equivalent to `RetryError::to_transient(3)`
+//!         }
+//!         std::io::ErrorKind::ConnectionReset => {
+//!             return Err(RetryError::retry_after(4, Duration::from_millis(10)));
+//!             // equivalent to `RetryError::to_retry_after(4, Duration::from_millis(10))`
+//!         }
+//!         std::io::ErrorKind::ConnectionAborted =>
+//!             // equivalent to `RetryError::to_retry_after(5, Duration::from_millis(15))`
+//!             RetryError::to_retry_after(5, Duration::from_millis(15))?,
+//!         err => RetryError::to_transient(6)? // equivalent to `return Err(RetryError::transient(6))`
+//!     };
+//!     Ok(0)
+//! }
+//! ```
+//!
+//! ## Features
 //! `[jitter]``
 //!
 //! To use jitter, add this to your Cargo.toml
 //!
 //! ```toml
 //! [dependencies]
-//! tokio-retry2 = { version = "0.4", features = ["jitter"] }
+//! tokio-retry2 = { version = "0.5", features = ["jitter"] }
 //! ```
 //!
 //! # Example
@@ -67,6 +103,7 @@
 
 mod action;
 mod condition;
+pub(crate) mod error;
 mod future;
 mod notify;
 /// Assorted retry strategies including fixed interval and exponential back-off.
@@ -74,4 +111,5 @@ pub mod strategy;
 
 pub use action::Action;
 pub use condition::Condition;
+pub use error::Error as RetryError;
 pub use future::{Retry, RetryIf};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,8 +53,8 @@
 //! use tokio_retry2::strategy::{ExponentialBackoff, jitter, MaxInterval};
 //!
 //! let retry_strategy = ExponentialBackoff::from_millis(10)
-//!    .map(jitter) // add jitter to the retry interval
 //!    .max_interval(10000) // set max interval to 10 seconds
+//!    .map(jitter) // add jitter to the retry interval
 //!    .take(3);    // limit to 3 retries
 //!````
 //!
@@ -68,6 +68,7 @@
 mod action;
 mod condition;
 mod future;
+mod notify;
 /// Assorted retry strategies including fixed interval and exponential back-off.
 pub mod strategy;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 //! ```rust,no_run
 
 //! use tokio_retry2::Retry;
-//! use tokio_retry2::strategy::ExponentialBackoff;
+//! use tokio_retry2::strategy::{ExponentialBackoff, MaxInterval};
 //!
 //! async fn action() -> Result<u64, ()> {
 //!     // do some real-world stuff here...
@@ -25,6 +25,7 @@
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), ()> {
 //! let retry_strategy = ExponentialBackoff::from_millis(10)
+//!     .max_interval(10000) // set max interval to 10 seconds
 //!     .take(3);    // limit to 3 retries
 //!
 //! let result = Retry::spawn(retry_strategy, action).await?;
@@ -46,14 +47,18 @@
 //!
 //! ```rust,no_run
 //! use tokio_retry2::Retry;
-//! use tokio_retry2::strategy::{ExponentialBackoff, jitter};
+//! use tokio_retry2::strategy::{ExponentialBackoff, jitter, MaxInterval};
 //!
 //! let retry_strategy = ExponentialBackoff::from_millis(10)
 //!    .map(jitter) // add jitter to the retry interval
+//!    .max_interval(10000) // set max interval to 10 seconds
 //!    .take(3);    // limit to 3 retries
+//!````
 //!
-//!
-//!
+//! ### NOTE:
+//! The time spent executing an action does not affect the intervals between
+//! retries. Therefore, for long-running functions it's a good idea to set up a deadline,
+//! to place an upper bound on the strategy execution time.
 
 #![allow(warnings)]
 

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -1,0 +1,14 @@
+use std::time::Duration;
+
+pub trait Notify<E> {
+    fn notify(&mut self, err: &E, duration: Duration);
+}
+
+impl<E, F> Notify<E> for F
+where
+    F: FnMut(&E, Duration),
+{
+    fn notify(&mut self, err: &E, duration: Duration) {
+        self(err, duration)
+    }
+}

--- a/src/strategy/exponential_backoff.rs
+++ b/src/strategy/exponential_backoff.rs
@@ -1,5 +1,5 @@
 use std::iter::Iterator;
-use std::time::Duration;
+use tokio::time::Duration;
 
 /// A retry strategy driven by exponential back-off.
 ///

--- a/src/strategy/exponential_backoff.rs
+++ b/src/strategy/exponential_backoff.rs
@@ -1,6 +1,5 @@
 use std::iter::Iterator;
 use std::time::Duration;
-use std::u64::MAX as U64_MAX;
 
 /// A retry strategy driven by exponential back-off.
 ///
@@ -22,7 +21,7 @@ impl ExponentialBackoff {
     pub const fn from_millis(base: u64) -> ExponentialBackoff {
         ExponentialBackoff {
             current: base,
-            base: base,
+            base,
             factor: 1u64,
             max_delay: None,
         }
@@ -53,7 +52,7 @@ impl Iterator for ExponentialBackoff {
         let duration = if let Some(duration) = self.current.checked_mul(self.factor) {
             Duration::from_millis(duration)
         } else {
-            Duration::from_millis(U64_MAX)
+            Duration::from_millis(u64::MAX)
         };
 
         // check if we reached max delay
@@ -66,7 +65,7 @@ impl Iterator for ExponentialBackoff {
         if let Some(next) = self.current.checked_mul(self.base) {
             self.current = next;
         } else {
-            self.current = U64_MAX;
+            self.current = u64::MAX;
         }
 
         Some(duration)
@@ -93,11 +92,11 @@ fn returns_some_exponential_base_2() {
 
 #[test]
 fn saturates_at_maximum_value() {
-    let mut s = ExponentialBackoff::from_millis(U64_MAX - 1);
+    let mut s = ExponentialBackoff::from_millis(u64::MAX - 1);
 
-    assert_eq!(s.next(), Some(Duration::from_millis(U64_MAX - 1)));
-    assert_eq!(s.next(), Some(Duration::from_millis(U64_MAX)));
-    assert_eq!(s.next(), Some(Duration::from_millis(U64_MAX)));
+    assert_eq!(s.next(), Some(Duration::from_millis(u64::MAX - 1)));
+    assert_eq!(s.next(), Some(Duration::from_millis(u64::MAX)));
+    assert_eq!(s.next(), Some(Duration::from_millis(u64::MAX)));
 }
 
 #[test]

--- a/src/strategy/exponential_backoff.rs
+++ b/src/strategy/exponential_backoff.rs
@@ -19,7 +19,7 @@ impl ExponentialBackoff {
     ///
     /// The resulting duration is calculated by taking the base to the `n`-th power,
     /// where `n` denotes the number of past attempts.
-    pub fn from_millis(base: u64) -> ExponentialBackoff {
+    pub const fn from_millis(base: u64) -> ExponentialBackoff {
         ExponentialBackoff {
             current: base,
             base: base,
@@ -33,13 +33,13 @@ impl ExponentialBackoff {
     /// For example, using a factor of `1000` will make each delay in units of seconds.
     ///
     /// Default factor is `1`.
-    pub fn factor(mut self, factor: u64) -> ExponentialBackoff {
+    pub const fn factor(mut self, factor: u64) -> ExponentialBackoff {
         self.factor = factor;
         self
     }
 
     /// Apply a maximum delay. No retry delay will be longer than this `Duration`.
-    pub fn max_delay(mut self, duration: Duration) -> ExponentialBackoff {
+    pub const fn max_delay(mut self, duration: Duration) -> ExponentialBackoff {
         self.max_delay = Some(duration);
         self
     }

--- a/src/strategy/exponential_backoff.rs
+++ b/src/strategy/exponential_backoff.rs
@@ -18,7 +18,7 @@ impl ExponentialBackoff {
     ///
     /// The resulting duration is calculated by taking the base to the `n`-th power,
     /// where `n` denotes the number of past attempts.
-    pub const fn from_millis(base: u64) -> ExponentialBackoff {
+    pub const fn from_millis(base: u64) -> Self {
         ExponentialBackoff {
             current: base,
             base,
@@ -40,6 +40,12 @@ impl ExponentialBackoff {
     /// Apply a maximum delay. No retry delay will be longer than this `Duration`.
     pub const fn max_delay(mut self, duration: Duration) -> ExponentialBackoff {
         self.max_delay = Some(duration);
+        self
+    }
+
+    /// Apply a maximum delay. No retry delay will be longer than this `Duration::from_millis`.
+    pub const fn max_delay_millis(mut self, duration: u64) -> ExponentialBackoff {
+        self.max_delay = Some(Duration::from_millis(duration));
         self
     }
 }

--- a/src/strategy/fibonacci_backoff.rs
+++ b/src/strategy/fibonacci_backoff.rs
@@ -1,6 +1,5 @@
 use std::iter::Iterator;
 use std::time::Duration;
-use std::u64::MAX as U64_MAX;
 
 /// A retry strategy driven by the fibonacci series.
 ///
@@ -57,7 +56,7 @@ impl Iterator for FibonacciBackoff {
         let duration = if let Some(duration) = self.curr.checked_mul(self.factor) {
             Duration::from_millis(duration)
         } else {
-            Duration::from_millis(U64_MAX)
+            Duration::from_millis(u64::MAX)
         };
 
         // check if we reached max delay
@@ -72,7 +71,7 @@ impl Iterator for FibonacciBackoff {
             self.next = next_next;
         } else {
             self.curr = self.next;
-            self.next = U64_MAX;
+            self.next = u64::MAX;
         }
 
         Some(duration)
@@ -92,9 +91,9 @@ fn returns_the_fibonacci_series_starting_at_10() {
 
 #[test]
 fn saturates_at_maximum_value() {
-    let mut iter = FibonacciBackoff::from_millis(U64_MAX);
-    assert_eq!(iter.next(), Some(Duration::from_millis(U64_MAX)));
-    assert_eq!(iter.next(), Some(Duration::from_millis(U64_MAX)));
+    let mut iter = FibonacciBackoff::from_millis(u64::MAX);
+    assert_eq!(iter.next(), Some(Duration::from_millis(u64::MAX)));
+    assert_eq!(iter.next(), Some(Duration::from_millis(u64::MAX)));
 }
 
 #[test]

--- a/src/strategy/fibonacci_backoff.rs
+++ b/src/strategy/fibonacci_backoff.rs
@@ -13,7 +13,7 @@ use std::time::Duration;
 /// for more details.
 #[derive(Debug, Clone)]
 pub struct FibonacciBackoff {
-    curr: u64,
+    current: u64,
     next: u64,
     factor: u64,
     max_delay: Option<Duration>,
@@ -24,7 +24,7 @@ impl FibonacciBackoff {
     /// given a base duration in milliseconds.
     pub const fn from_millis(millis: u64) -> FibonacciBackoff {
         FibonacciBackoff {
-            curr: millis,
+            current: millis,
             next: millis,
             factor: 1u64,
             max_delay: None,
@@ -46,6 +46,12 @@ impl FibonacciBackoff {
         self.max_delay = Some(duration);
         self
     }
+
+    /// Apply a maximum delay. No retry delay will be longer than this `Duration::from_millis`.
+    pub const fn max_delay_millis(mut self, duration: u64) -> FibonacciBackoff {
+        self.max_delay = Some(Duration::from_millis(duration));
+        self
+    }
 }
 
 impl Iterator for FibonacciBackoff {
@@ -53,7 +59,7 @@ impl Iterator for FibonacciBackoff {
 
     fn next(&mut self) -> Option<Duration> {
         // set delay duration by applying factor
-        let duration = if let Some(duration) = self.curr.checked_mul(self.factor) {
+        let duration = if let Some(duration) = self.current.checked_mul(self.factor) {
             Duration::from_millis(duration)
         } else {
             Duration::from_millis(u64::MAX)
@@ -66,11 +72,11 @@ impl Iterator for FibonacciBackoff {
             }
         }
 
-        if let Some(next_next) = self.curr.checked_add(self.next) {
-            self.curr = self.next;
+        if let Some(next_next) = self.current.checked_add(self.next) {
+            self.current = self.next;
             self.next = next_next;
         } else {
-            self.curr = self.next;
+            self.current = self.next;
             self.next = u64::MAX;
         }
 

--- a/src/strategy/fibonacci_backoff.rs
+++ b/src/strategy/fibonacci_backoff.rs
@@ -1,5 +1,5 @@
 use std::iter::Iterator;
-use std::time::Duration;
+use tokio::time::Duration;
 
 /// A retry strategy driven by the fibonacci series.
 ///

--- a/src/strategy/fibonacci_backoff.rs
+++ b/src/strategy/fibonacci_backoff.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 /// perform better and lead to better throughput than the `ExponentialBackoff`
 /// strategy.
 ///
-/// See ["A Performance Comparison of Different Backoff Algorithms under Different Rebroadcast Probabilities for MANETs."](http://www.comp.leeds.ac.uk/ukpew09/papers/12.pdf)
+/// See ["A Performance Comparison of Different Backoff Algorithms under Different Rebroadcast Probabilities for MANETs."](https://www.researchgate.net/profile/Saher-Manaseer/publication/255672213_A_Performance_Comparison_of_Different_Backoff_Algorithms_under_Different_Rebroadcast_Probabilities_for_MANET's/links/542d40220cf29bbc126d2378/A-Performance-Comparison-of-Different-Backoff-Algorithms-under-Different-Rebroadcast-Probabilities-for-MANETs.pdf)
 /// for more details.
 #[derive(Debug, Clone)]
 pub struct FibonacciBackoff {

--- a/src/strategy/fibonacci_backoff.rs
+++ b/src/strategy/fibonacci_backoff.rs
@@ -23,7 +23,7 @@ pub struct FibonacciBackoff {
 impl FibonacciBackoff {
     /// Constructs a new fibonacci back-off strategy,
     /// given a base duration in milliseconds.
-    pub fn from_millis(millis: u64) -> FibonacciBackoff {
+    pub const fn from_millis(millis: u64) -> FibonacciBackoff {
         FibonacciBackoff {
             curr: millis,
             next: millis,
@@ -37,13 +37,13 @@ impl FibonacciBackoff {
     /// For example, using a factor of `1000` will make each delay in units of seconds.
     ///
     /// Default factor is `1`.
-    pub fn factor(mut self, factor: u64) -> FibonacciBackoff {
+    pub const fn factor(mut self, factor: u64) -> FibonacciBackoff {
         self.factor = factor;
         self
     }
 
     /// Apply a maximum delay. No retry delay will be longer than this `Duration`.
-    pub fn max_delay(mut self, duration: Duration) -> FibonacciBackoff {
+    pub const fn max_delay(mut self, duration: Duration) -> FibonacciBackoff {
         self.max_delay = Some(duration);
         self
     }

--- a/src/strategy/fixed_interval.rs
+++ b/src/strategy/fixed_interval.rs
@@ -1,5 +1,5 @@
 use std::iter::Iterator;
-use std::time::Duration;
+use tokio::time::Duration;
 
 /// A retry strategy driven by a fixed interval.
 #[derive(Debug, Clone)]

--- a/src/strategy/fixed_interval.rs
+++ b/src/strategy/fixed_interval.rs
@@ -9,8 +9,8 @@ pub struct FixedInterval {
 
 impl FixedInterval {
     /// Constructs a new fixed interval strategy.
-    pub fn new(duration: Duration) -> FixedInterval {
-        FixedInterval { duration: duration }
+    pub const fn new(duration: Duration) -> FixedInterval {
+        FixedInterval { duration }
     }
 
     /// Constructs a new fixed interval strategy,

--- a/src/strategy/fixed_interval.rs
+++ b/src/strategy/fixed_interval.rs
@@ -8,17 +8,17 @@ pub struct FixedInterval {
 }
 
 impl FixedInterval {
-    /// Constructs a new fixed interval strategy.
-    pub const fn new(duration: Duration) -> FixedInterval {
-        FixedInterval { duration }
-    }
-
     /// Constructs a new fixed interval strategy,
     /// given a duration in milliseconds.
-    pub fn from_millis(millis: u64) -> FixedInterval {
+    pub const fn from_millis(millis: u64) -> FixedInterval {
         FixedInterval {
             duration: Duration::from_millis(millis),
         }
+    }
+
+    /// Constructs a new fixed interval strategy.
+    pub const fn new(duration: Duration) -> FixedInterval {
+        FixedInterval { duration }
     }
 }
 

--- a/src/strategy/jitter.rs
+++ b/src/strategy/jitter.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use tokio::time::Duration;
 
 pub fn jitter(duration: Duration) -> Duration {
     duration.mul_f64(rand::random::<f64>())

--- a/src/strategy/max_interval.rs
+++ b/src/strategy/max_interval.rs
@@ -1,0 +1,59 @@
+use std::time::Duration;
+use std::time::Instant;
+
+/// Wraps a strategy, applying `max_interval``, after which strategy will
+/// stop retrying.
+pub trait MaxInterval: Iterator<Item = Duration> {
+    /// Applies a max_interval for a strategy. In `max_duration` from now,
+    /// the strategy will stop retrying.
+    fn max_interval(self, max_duration: Duration) -> MaxIntervalIterator<Self>
+    where
+        Self: Sized,
+    {
+        MaxIntervalIterator {
+            iter: self,
+            start: Instant::now(),
+            max_duration,
+        }
+    }
+}
+
+impl<I> MaxInterval for I where I: Iterator<Item = Duration> {}
+
+/// A strategy wrapper with applied max_interval,
+/// created by [`MaxInterval::max_interval`] function.
+#[derive(Debug)]
+pub struct MaxIntervalIterator<I> {
+    iter: I,
+    start: Instant,
+    max_duration: Duration,
+}
+
+impl<I: Iterator<Item = Duration>> Iterator for MaxIntervalIterator<I> {
+    type Item = Duration;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.start.elapsed() > self.max_duration {
+            None
+        } else {
+            self.iter.next()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::strategy::FixedInterval;
+
+    #[tokio::test]
+    async fn returns_none_after_max_interval_passes() {
+        let mut s = FixedInterval::from_millis(10).max_interval(Duration::from_millis(50));
+        assert_eq!(s.next(), Some(Duration::from_millis(10)));
+        tokio::time::sleep(Duration::from_millis(15)).await;
+        assert_eq!(s.next(), Some(Duration::from_millis(10)));
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert_eq!(s.next(), None);
+    }
+}

--- a/src/strategy/max_interval.rs
+++ b/src/strategy/max_interval.rs
@@ -1,5 +1,5 @@
-use std::time::Duration;
 use std::time::Instant;
+use tokio::time::Duration;
 
 /// Wraps a strategy, applying `max_interval``, after which strategy will
 /// stop retrying.

--- a/src/strategy/mod.rs
+++ b/src/strategy/mod.rs
@@ -1,9 +1,12 @@
 mod exponential_backoff;
 mod fibonacci_backoff;
 mod fixed_interval;
+#[cfg(feature = "jitter")]
 mod jitter;
 
 pub use self::exponential_backoff::ExponentialBackoff;
 pub use self::fibonacci_backoff::FibonacciBackoff;
 pub use self::fixed_interval::FixedInterval;
+
+#[cfg(feature = "jitter")]
 pub use self::jitter::jitter;

--- a/src/strategy/mod.rs
+++ b/src/strategy/mod.rs
@@ -3,10 +3,12 @@ mod fibonacci_backoff;
 mod fixed_interval;
 #[cfg(feature = "jitter")]
 mod jitter;
+mod max_interval;
 
 pub use self::exponential_backoff::ExponentialBackoff;
 pub use self::fibonacci_backoff::FibonacciBackoff;
 pub use self::fixed_interval::FixedInterval;
+pub use self::max_interval::MaxInterval;
 
 #[cfg(feature = "jitter")]
 pub use self::jitter::jitter;

--- a/tests/future.rs
+++ b/tests/future.rs
@@ -3,7 +3,7 @@ use std::iter::Take;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
-use tokio_retry::{Retry, RetryIf};
+use tokio_retry2::{Retry, RetryIf};
 
 #[tokio::test]
 async fn attempts_just_once() {
@@ -22,7 +22,7 @@ async fn attempts_just_once() {
 
 #[tokio::test]
 async fn attempts_until_max_retries_exceeded() {
-    use tokio_retry::strategy::FixedInterval;
+    use tokio_retry2::strategy::FixedInterval;
     let s = FixedInterval::from_millis(100).take(2);
     let counter = Arc::new(AtomicUsize::new(0));
     let cloned_counter = counter.clone();
@@ -38,7 +38,7 @@ async fn attempts_until_max_retries_exceeded() {
 
 #[tokio::test]
 async fn attempts_until_success() {
-    use tokio_retry::strategy::FixedInterval;
+    use tokio_retry2::strategy::FixedInterval;
     let s = FixedInterval::from_millis(100);
     let counter = Arc::new(AtomicUsize::new(0));
     let cloned_counter = counter.clone();
@@ -58,7 +58,7 @@ async fn attempts_until_success() {
 
 #[tokio::test]
 async fn compatible_with_tokio_core() {
-    use tokio_retry::strategy::FixedInterval;
+    use tokio_retry2::strategy::FixedInterval;
     let s = FixedInterval::from_millis(100);
     let counter = Arc::new(AtomicUsize::new(0));
     let cloned_counter = counter.clone();
@@ -78,7 +78,7 @@ async fn compatible_with_tokio_core() {
 
 #[tokio::test]
 async fn attempts_retry_only_if_given_condition_is_true() {
-    use tokio_retry::strategy::FixedInterval;
+    use tokio_retry2::strategy::FixedInterval;
     let s = FixedInterval::from_millis(100).take(5);
     let counter = Arc::new(AtomicUsize::new(0));
     let cloned_counter = counter.clone();


### PR DESCRIPTION
# Error Handling

- Early exit is done with RetryError::Permanent;
- Continue with retry strategy is done with RetryError::Transient;
- Continue with retry strategy adding an extra duration is done with RetryError::Transient setting `retry_after` field;
One key difference between `tokio-retry2` and `tokio-retry` is the fact that `tokio-retry2` supports early exits from the retry loop based on your error type. This allows you to pattern match your errors and define if you want to continue retrying or not. The following functions are helper functions to deal with it:

```rust,no_run
use tokio_retry2::{Retry, RetryError};
use std::time::Duration;

async fn action() -> Result<u64, RetryError<usize>> {
    // do some real-world stuff here...
    // get and error named `err`
   let err = std::io::ErrorKind::AddrInUse;
    match err {
        std::io::ErrorKind::NotFound => RetryError::to_permanent(1)?, // equivalent to return Err(RetryError::permanent(2))`;
        std::io::ErrorKind::PermissionDenied => {
            return Err(RetryError::permanent(2)); // equivalent to `RetryError::to_permanent(2)`
        }
        std::io::ErrorKind::ConnectionRefused => {
            return Err(RetryError::transient(3)); // equivalent to `RetryError::to_transient(3)`
        }
        std::io::ErrorKind::ConnectionReset => {
            return Err(RetryError::retry_after(4, Duration::from_millis(10)));
            // equivalent to `RetryError::to_retry_after(4, Duration::from_millis(10))`
        }
        std::io::ErrorKind::ConnectionAborted =>
            // equivalent to `RetryError::to_retry_after(5, Duration::from_millis(15))`
            RetryError::to_retry_after(5, Duration::from_millis(15))?,
        err => RetryError::to_transient(6)? // equivalent to `return Err(RetryError::transient(6))`
    };
    Ok(0)
}
```