### PR TITLE
 deprecate `spawn` in favor of `start`...

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ async fn main() -> Result<(), ()> {
         .map(jitter) // add jitter to delays
         .take(3);    // limit to 3 retries
 
-    let result = Retry::spawn(retry_strategy, action).await?;
+    let result = Retry::start(retry_strategy, action).await?;
 
     Ok(())
 }

--- a/src/action.rs
+++ b/src/action.rs
@@ -1,2 +1,0 @@
-use std::future::Future;
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 //!     .map(jitter) // add jitter to delays
 //!     .take(3);    // limit to 3 retries
 //!
-//! let result = Retry::spawn(retry_strategy, action).await?;
+//! let result = Retry::start(retry_strategy, action).await?;
 //! # Ok(())
 //! # }
 //! ```
@@ -87,10 +87,15 @@ where
     I: Iterator<Item = Duration>,
     A: Action,
 {
-    pub fn spawn<T: IntoIterator<IntoIter = I, Item = Duration>>(strategy: T, action: A) -> Self {
+    pub fn start<T: IntoIterator<IntoIter = I, Item = Duration>>(strategy: T, action: A) -> Self {
         Self {
-            retry_if: RetryIf::spawn(strategy, action, (|_| true) as fn(&A::Error) -> bool),
+            retry_if: RetryIf::start(strategy, action, (|_| true) as fn(&A::Error) -> bool),
         }
+    }
+    
+    #[deprecated = "superceeded by `start` to avoid confusion with usual Tokio terminology"]
+    pub fn spawn<T: IntoIterator<IntoIter = I, Item = Duration>>(strategy: T, action: A) -> Self {
+        Self::start(strategy, action)
     }
 }
 
@@ -108,8 +113,8 @@ where
 }
 
 pin_project! {
-    /// Future that drives multiple attempts at an action via a retry strategy. Retries are only attempted if
-    /// the `Error` returned by the future satisfies a given condition.
+    /// Future that drives multiple attempts at an action via a retry strategy. Retries are only attempted 
+    /// if the `Error` returned by the future satisfies a given condition.
     pub struct RetryIf<I, A, C>
     where
         I: Iterator<Item = Duration>,
@@ -130,7 +135,7 @@ where
     A: Action,
     C: Condition<A::Error>,
 {
-    pub fn spawn<T: IntoIterator<IntoIter = I, Item = Duration>>(
+    pub fn start<T: IntoIterator<IntoIter = I, Item = Duration>>(
         strategy: T,
         mut action: A,
         condition: C,
@@ -144,6 +149,17 @@ where
             condition,
         }
     }
+
+    #[deprecated = "superceeded by `start` to avoid confusion with usual Tokio terminology"]
+    pub fn spawn<T: IntoIterator<IntoIter = I, Item = Duration>>(
+        strategy: T,
+        action: A,
+        condition: C,
+    ) -> Self {Self::start(
+        strategy,
+        action,
+        condition,
+    )}
 
     fn attempt(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<A::Item, A::Error>> {
         let future = {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,7 @@ where
             retry_if: RetryIf::start(strategy, action, (|_| true) as fn(&A::Error) -> bool),
         }
     }
-    
+
     #[deprecated = "superceeded by `start` to avoid confusion with usual Tokio terminology"]
     pub fn spawn<T: IntoIterator<IntoIter = I, Item = Duration>>(strategy: T, action: A) -> Self {
         Self::start(strategy, action)
@@ -113,7 +113,7 @@ where
 }
 
 pin_project! {
-    /// Future that drives multiple attempts at an action via a retry strategy. Retries are only attempted 
+    /// Future that drives multiple attempts at an action via a retry strategy. Retries are only attempted
     /// if the `Error` returned by the future satisfies a given condition.
     pub struct RetryIf<I, A, C>
     where
@@ -155,11 +155,9 @@ where
         strategy: T,
         action: A,
         condition: C,
-    ) -> Self {Self::start(
-        strategy,
-        action,
-        condition,
-    )}
+    ) -> Self {
+        Self::start(strategy, action, condition)
+    }
 
     fn attempt(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<A::Item, A::Error>> {
         let future = {

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -32,13 +32,13 @@ impl ExponentialBackoff {
     /// For example, using a factor of `1000` will make each delay in units of seconds.
     ///
     /// Default factor is `1`.
-    pub fn factor(mut self, factor: u64) -> Self {
+    pub const fn factor(mut self, factor: u64) -> Self {
         self.factor = factor;
         self
     }
 
     /// Apply a maximum delay. No retry delay will be longer than this `Duration`.
-    pub fn max_delay(mut self, duration: Duration) -> Self {
+    pub const fn max_delay(mut self, duration: Duration) -> Self {
         self.max_delay = Some(duration);
         self
     }
@@ -105,13 +105,13 @@ impl FibonacciBackoff {
     /// For example, using a factor of `1000` will make each delay in units of seconds.
     ///
     /// Default factor is `1`.
-    pub fn factor(mut self, factor: u64) -> Self {
+    pub const fn factor(mut self, factor: u64) -> Self {
         self.factor = factor;
         self
     }
 
     /// Apply a maximum delay. No retry delay will be longer than this `Duration`.
-    pub fn max_delay(mut self, duration: Duration) -> Self {
+    pub const fn max_delay(mut self, duration: Duration) -> Self {
         self.max_delay = Some(duration);
         self
     }
@@ -155,7 +155,7 @@ pub struct FixedInterval {
 
 impl FixedInterval {
     /// Constructs a new fixed interval strategy.
-    pub fn new(duration: Duration) -> Self {
+    pub const fn new(duration: Duration) -> Self {
         Self { duration }
     }
 

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -56,19 +56,17 @@ impl Iterator for ExponentialBackoff {
         };
 
         // check if we reached max delay
-        if let Some(ref max_delay) = self.max_delay {
-            if duration > *max_delay {
-                return Some(*max_delay);
-            }
-        }
-
-        if let Some(next) = self.current.checked_mul(self.base) {
-            self.current = next;
+        if self.max_delay.is_some_and(|max_delay| duration > max_delay) {
+            self.max_delay
         } else {
-            self.current = u64::MAX;
-        }
+            if let Some(next) = self.current.checked_mul(self.base) {
+                self.current = next;
+            } else {
+                self.current = u64::MAX;
+            }
 
-        Some(duration)
+            Some(duration)
+        }
     }
 }
 

--- a/tests/future.rs
+++ b/tests/future.rs
@@ -10,7 +10,7 @@ async fn attempts_just_once() {
     use core::iter::empty;
     let counter = Arc::new(AtomicUsize::new(0));
     let cloned_counter = counter.clone();
-    let future = Retry::spawn(empty(), move || {
+    let future = Retry::start(empty(), move || {
         cloned_counter.fetch_add(1, Ordering::SeqCst);
         future::ready(Err::<(), u64>(42))
     });
@@ -26,7 +26,7 @@ async fn attempts_until_max_retries_exceeded() {
     let s = FixedInterval::from_millis(100).take(2);
     let counter = Arc::new(AtomicUsize::new(0));
     let cloned_counter = counter.clone();
-    let future = Retry::spawn(s, move || {
+    let future = Retry::start(s, move || {
         cloned_counter.fetch_add(1, Ordering::SeqCst);
         future::ready(Err::<(), u64>(42))
     });
@@ -42,7 +42,7 @@ async fn attempts_until_success() {
     let s = FixedInterval::from_millis(100);
     let counter = Arc::new(AtomicUsize::new(0));
     let cloned_counter = counter.clone();
-    let future = Retry::spawn(s, move || {
+    let future = Retry::start(s, move || {
         let previous = cloned_counter.fetch_add(1, Ordering::SeqCst);
         if previous < 3 {
             future::ready(Err::<(), u64>(42))
@@ -62,7 +62,7 @@ async fn compatible_with_tokio_core() {
     let s = FixedInterval::from_millis(100);
     let counter = Arc::new(AtomicUsize::new(0));
     let cloned_counter = counter.clone();
-    let future = Retry::spawn(s, move || {
+    let future = Retry::start(s, move || {
         let previous = cloned_counter.fetch_add(1, Ordering::SeqCst);
         if previous < 3 {
             future::ready(Err::<(), u64>(42))
@@ -82,7 +82,7 @@ async fn attempts_retry_only_if_given_condition_is_true() {
     let s = FixedInterval::from_millis(100).take(5);
     let counter = Arc::new(AtomicUsize::new(0));
     let cloned_counter = counter.clone();
-    let future: RetryIf<Take<FixedInterval>, _, fn(&usize) -> _> = RetryIf::spawn(
+    let future: RetryIf<Take<FixedInterval>, _, fn(&usize) -> _> = RetryIf::start(
         s,
         move || {
             let previous = cloned_counter.fetch_add(1, Ordering::SeqCst);


### PR DESCRIPTION
...per #40 

Could you check I did not left something back & did not messed up the language.